### PR TITLE
Fix php warning, when render a index zero of array

### DIFF
--- a/src/lightncandy.inc
+++ b/src/lightncandy.inc
@@ -489,7 +489,7 @@ $libstr
         if ($v == '.') {
             return Array('.');
         }
-        return $v ? explode('.', $v) : null;
+        return $v ? explode('.', $v) : array(0);
     }
 
     /**


### PR DESCRIPTION
When I run the php code at the bottom of comment. It will echo a warning that is  「PHP Warning:  Invalid argument supplied for foreach() in  /lightncandy.inc on line 549」.

The warning was happened in  LightnCandy::compile() function. 
I had try @LightnCandy::compile() to hide this warning.
But I thought it is wrong to hide warning message at compilation.

The root cause is this code "{{0}}", "{{}}" will be replaced to be a "null". It will cause "for-each" to output a warning.
I thought "{{}}"  should not be exist in lightncandy template.
So I changed the return value of "{{0}}"  to be "array(0)".

Or any better idea?

============= test code =================
<?php
require('../src/lightncandy.inc');
$template = <<<TEMP
{{#each list}}
    Name {{0}} , Age {{1}} ";
{{/each}}
TEMP;

$php = LightnCandy::compile($template, Array('flags' => LightnCandy::FLAG_HANDLEBARSJS));

$renderer = LightnCandy::prepare($php);

$data = array();
$data[] = array("John", "12");
$data[] = array("Marry", "22");

echo $renderer(Array('list' => $data));
