### PR TITLE
Closure syntax error fix and phpdoc improvements

### DIFF
--- a/src/lightncandy.php
+++ b/src/lightncandy.php
@@ -403,7 +403,7 @@ $libstr
         $file->seek($ref->getEndLine() - 1);
         $epos = $file->ftell();
 
-        return preg_replace('/^.*?function\s.*?\\((.+?)\\}[,\\s]*$/s', 'function($1}', substr($lines, $spos, $epos - $spos));
+        return preg_replace('/^.*?function\s.*?\\((.+?)\\}[,\\s]*;?$/s', 'function($1}', substr($lines, $spos, $epos - $spos));
     }
 
     /**


### PR DESCRIPTION
I've made some improvements to the phpdoc declarations in lightncandy. These should fix some type hinting issues in modern editors.

More importantly, I had a bug where closures were being written to the blockhelpers array with a trailing semicolon, triggering a syntax error: `array(function () {};)`. This adjustment to the regex corrects that.
