### PR TITLE
Php error when variable doesn't exist in data

### DIFF
--- a/src/lightncandy.php
+++ b/src/lightncandy.php
@@ -729,7 +729,7 @@ $libstr
         array_pop($var);
         $p = count($var) ? self::getArrayCode($var) : '';
 
-        return "(is_array($base$p) ? $base$n : null)";
+        return "(is_array($base$p) && isset($base$n) !== FALSE ? $base$n : null)";
     }
 
     /**


### PR DESCRIPTION
I'm using Lightncandy without since last January without any problems but after upgrade to v.10
got some php errors when trying to use a variable that does not exists in the data.

After make one change in getVariableName fixed it, maybe. What do you think? 

How to reproduce:
template:
{{#if var_1}}
  Var_1 value: {{{var_1}}}
{{/if}}
{{#if var_2}}
  Var_2 value: {{{var_2}}}
{{/if}}

$test_data      = array ('var_1' => 'Hello', 'var_2' => 'world!');
$test_data_error = array ('var_1' => 'Hello');

Compile options:

$lightnCandy_flags =
LightnCandy::FLAG_ERROR_LOG 
| LightnCandy::FLAG_HANDLEBARSJS
| LightnCandy::FLAG_ERROR_EXCEPTION
| LightnCandy::FLAG_EXTHELPER
;
