### PR TITLE
Implement SafeString escaping passthrough

### DIFF
--- a/src/lightncandy.php
+++ b/src/lightncandy.php
@@ -41,6 +41,7 @@ class LightnCandy {
     const FLAG_ADVARNAME = 512;
     const FLAG_SPACECTL = 1024;
     const FLAG_NAMEDARG = 2048;
+    const FLAG_SAFESTRING = 16384;
 
     // PHP performance flags
     const FLAG_EXTHELPER = 4096;
@@ -50,7 +51,7 @@ class LightnCandy {
     const FLAG_BESTPERFORMANCE = 8192; // FLAG_ECHO
     const FLAG_JS = 24; // FLAG_JSTRUE + FLAG_JSOBJECT
     const FLAG_HANDLEBARS = 4064; // FLAG_THIS + FLAG_WITH + FLAG_PARENT + FLAG_JSQUOTE + FLAG_ADVARNAME + FLAG_SPACECTL + FLAG_NAMEDARG
-    const FLAG_HANDLEBARSJS = 4088; // FLAG_JS + FLAG_HANDLEBARS
+    const FLAG_HANDLEBARSJS = 20472; // FLAG_JS + FLAG_SAFESTRING + FLAG_HANDLEBARS
 
     // RegExps
     const PARTIAL_SEARCH = '/\\{\\{>[ \\t]*(.+?)[ \\t]*\\}\\}/s';
@@ -180,6 +181,7 @@ $libstr
                 'advar' => $flags & self::FLAG_ADVARNAME,
                 'namev' => $flags & self::FLAG_NAMEDARG,
                 'exhlp' => $flags & self::FLAG_EXTHELPER,
+                'safestring' => $flags & self::FLAG_SAFESTRING,
             ),
             'level' => 0,
             'stack' => Array(),
@@ -244,6 +246,10 @@ $libstr
         );
 
         $context['ops']['enc'] = $context['flags']['jsquote'] ? 'encq' : 'enc';
+        if ( $context['flags']['safestring'] ) {
+            $context['ops']['enc'] = 's' . $context['ops']['enc'];
+
+        }
         return self::buildHelperTable(self::buildHelperTable($context, $options), $options, 'blockhelpers');
     }
 
@@ -1383,7 +1389,13 @@ $libstr
         if ($context['flags']['jsobj'] || $context['flags']['jstrue']) {
             return $context['ops']['seperator'] . self::getFuncName($context, $raw ? 'raw' : $context['ops']['enc']) . "($v, \$cx){$context['ops']['seperator']}";
         } else {
-            return $raw ? "{$context['ops']['seperator']}$v{$context['ops']['seperator']}" : "{$context['ops']['seperator']}htmlentities($v, ENT_QUOTES, 'UTF-8'){$context['ops']['seperator']}";
+            if ($context['flags']['safestring']) {
+                $inner = $raw ? '\$t' : "htmlentities(\$t, ENT_QUOTES, 'UTF-8')";
+                $v = "((\$t = $v && \$t instanceof LCSafeString) ? \$t->string : $inner)";
+            } elseif (!$raw) {
+                $v = "htmlentities($v, ENT_QUOTES, 'UTF-8)";
+            }
+            return "{$context['ops']['seperator']}$v{$context['ops']['seperator']}";
         }
     }
 
@@ -1534,6 +1546,12 @@ class LCRun2 {
             }
         }
 
+        if ($v instanceof LCSafeString) {
+            if ($cx['flags']['safestring']) {
+                return $v->string;
+            }
+        }
+
         if (is_array($v)) {
             if ($cx['flags']['jsobj']) {
                 if (count(array_diff_key($v, array_keys(array_keys($v)))) > 0) {
@@ -1568,6 +1586,25 @@ class LCRun2 {
     }
 
     /**
+     * LightnCandy runtime method for {{var}} with SAFESTRING feature enabled.
+     *
+     * @param mixed $var value to be htmlencoded
+     * @param array $cx render time context
+     *
+     * @return string The htmlencoded value of the specified variable
+     *
+     * @expect 'a' when input 'a', Array()
+     * @expect 'a&amp;b' when input 'a&b', Array()
+     * @expect 'a&#039;b' when input 'a\'b', Array()
+     * @expect 'a&b' when input new LCSafeString('a&b'), Array()
+     */
+    public static function senc($var, $cx) {
+        return $var instanceof LCSafeString
+            ? $var->string
+            : htmlentities(self::raw($var, $cx), ENT_QUOTES, 'UTF-8');
+    }
+
+    /**
      * LightnCandy runtime method for {{var}} , and deal with single quote to same as handlebars.js .
      *
      * @param mixed $var value to be htmlencoded
@@ -1581,6 +1618,27 @@ class LCRun2 {
      */
     public static function encq($var, $cx) {
         return preg_replace('/&#039;/', '&#x27;', htmlentities(self::raw($var, $cx), ENT_QUOTES, 'UTF-8'));
+    }
+
+    /**
+     * LightnCandy runtime method for {{var}} , and deal with single quote to same as handlebars.js
+     * with the SAFESTRING feature enabled.
+     *
+     * @param mixed $var value to be htmlencoded
+     * @param array $cx render time context
+     *
+     * @return string The htmlencoded value of the specified variable
+     *
+     * @expect 'a' when input 'a', Array()
+     * @expect 'a&amp;b' when input 'a&b', Array()
+     * @expect 'a&#x27;b' when input 'a\'b', Array()
+     * @expect 'a&b' when input new LCSafeString('a&b'), Array()
+     */
+    public static function sencq($var, $cx) {
+        return $var instanceof LCSafeString
+            ? $var->string
+            : preg_replace('/&#039;/', '&#x27;', htmlentities(self::raw($var, $cx), ENT_QUOTES, 'UTF-8'));
+
     }
 
     /**
@@ -1702,7 +1760,11 @@ class LCRun2 {
      *
      * @expect '=-=' when input 'a', Array('-'), 'raw', Array('helpers' => Array('a' => function ($i) {return "=$i=";}))
      * @expect '=&amp;=' when input 'a', Array('&'), 'enc', Array('helpers' => Array('a' => function ($i) {return "=$i=";}))
+     * @expect '=&amp;=' when input 'a', Array('&'), 'senc', Array('helpers' => Array('a' => function ($i) {return "=$i=";}))
+     * @expect '=&=' when input 'a', Array('&'), 'senc', Array('helpers' => Array('a' => function ($i) {return new LCSafeString("=$i=");}))
      * @expect '=&#x27;=' when input 'a', Array('\''), 'encq', Array('helpers' => Array('a' => function ($i) {return "=$i=";}))
+     * @expect '=&#x27;=' when input 'a', Array('\''), 'sencq', Array('helpers' => Array('a' => function ($i) {return "=$i=";}))
+     * @expect '=\'=' when input 'a', Array('\''), 'sencq', Array('helpers' => Array('a' => function ($i) {return new LCSafeString("=$i=");}))
      * @expect '=b=' when input 'a', Array('a' => 'b'), 'raw', Array('helpers' => Array('a' => function ($i) {return "={$i['a']}=";})), true
      */
     public static function ch($ch, $vars, $op, &$cx, $named = false) {
@@ -1713,8 +1775,18 @@ class LCRun2 {
 
         $r = call_user_func_array($cx['helpers'][$ch], $named ? Array($args) : $args);
         switch ($op) {
+            case 'senc':
+                if ($r instanceof LCSafeString) {
+                    return $r->string;
+                }
+                // fall through
             case 'enc': 
                 return htmlentities($r, ENT_QUOTES, 'UTF-8');
+            case 'sencq':
+                if ($r instanceof LCSafeString) {
+                    return $r->string;
+                }
+                //fall through
             case 'encq':
                 return preg_replace('/&#039;/', '&#x27;', htmlentities($r, ENT_QUOTES, 'UTF-8'));
             default:
@@ -1748,6 +1820,13 @@ class LCRun2 {
         $ret = $cb($cx, $r);
         array_pop($cx['scopes']);
         return $ret;
+    }
+}
+
+class LCSafeString {
+    public $string;
+    public function __construct($string) {
+        $this->string = $string;
     }
 }
 ?>

--- a/tests/LCRun2Test.php
+++ b/tests/LCRun2Test.php
@@ -157,6 +157,24 @@ class LCRun2Test extends PHPUnit_Framework_TestCase
         ));
     }
     /**
+     * @covers LCRun2::senc
+     */
+    public function testOn_senc() {
+        $method = new ReflectionMethod('LCRun2', 'senc');
+        $this->assertEquals('a', $method->invoke(null,
+            'a', Array()
+        ));
+        $this->assertEquals('a&amp;b', $method->invoke(null,
+            'a&b', Array()
+        ));
+        $this->assertEquals('a&#039;b', $method->invoke(null,
+            'a\'b', Array()
+        ));
+        $this->assertEquals('a&b', $method->invoke(null,
+            new LCSafeString('a&b'), Array()
+        ));
+    }
+    /**
      * @covers LCRun2::encq
      */
     public function testOn_encq() {
@@ -169,6 +187,24 @@ class LCRun2Test extends PHPUnit_Framework_TestCase
         ));
         $this->assertEquals('a&#x27;b', $method->invoke(null,
             'a\'b', Array()
+        ));
+    }
+    /**
+     * @covers LCRun2::sencq
+     */
+    public function testOn_sencq() {
+        $method = new ReflectionMethod('LCRun2', 'sencq');
+        $this->assertEquals('a', $method->invoke(null,
+            'a', Array()
+        ));
+        $this->assertEquals('a&amp;b', $method->invoke(null,
+            'a&b', Array()
+        ));
+        $this->assertEquals('a&#x27;b', $method->invoke(null,
+            'a\'b', Array()
+        ));
+        $this->assertEquals('a&b', $method->invoke(null,
+            new LCSafeString('a&b'), Array()
         ));
     }
     /**
@@ -242,8 +278,20 @@ class LCRun2Test extends PHPUnit_Framework_TestCase
         $this->assertEquals('=&amp;=', $method->invoke(null,
             'a', Array('&'), 'enc', Array('helpers' => Array('a' => function ($i) {return "=$i=";}))
         ));
+        $this->assertEquals('=&amp;=', $method->invoke(null,
+            'a', Array('&'), 'senc', Array('helpers' => Array('a' => function ($i) {return "=$i=";}))
+        ));
+        $this->assertEquals('=&=', $method->invoke(null,
+            'a', Array('&'), 'senc', Array('helpers' => Array('a' => function ($i) {return new LCSafeString("=$i=");}))
+        ));
         $this->assertEquals('=&#x27;=', $method->invoke(null,
             'a', Array('\''), 'encq', Array('helpers' => Array('a' => function ($i) {return "=$i=";}))
+        ));
+        $this->assertEquals('=&#x27;=', $method->invoke(null,
+            'a', Array('\''), 'sencq', Array('helpers' => Array('a' => function ($i) {return "=$i=";}))
+        ));
+        $this->assertEquals('=\'=', $method->invoke(null,
+            'a', Array('\''), 'sencq', Array('helpers' => Array('a' => function ($i) {return new LCSafeString("=$i=");}))
         ));
         $this->assertEquals('=b=', $method->invoke(null,
             'a', Array('a' => 'b'), 'raw', Array('helpers' => Array('a' => function ($i) {return "={$i['a']}=";})), true


### PR DESCRIPTION
Handlebars.js and other templating engines offer a way to return a value
from a helper and not have it escaped based on the helpers choice, rather
than the templates.  This adds a new feature flag and associated code to
create a new LCSafeString class.  When returned from a helper the contents
of the LCSafeString are output as-is.

There may be some interactions with LCRun2::raw that i don't understand yet.

Addresses https://github.com/zordius/lightncandy/issues/25
