### PR TITLE
new extended helper encode/escape logic, fix php warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,8 +221,6 @@ The input arguments are processed by LightnCandy automatically, you do not need 
                             // and processed {{{../name}}} as second parameter into the helper
 ```
 
-The return value of your custom helper should be a string. When your custom helper be executed from {{ }} , the return value will be HTML encoded. You may execute your helper by {{{ }}} , then the original helper return value will be outputted directly.
-
 When you pass arguments as `name=value` pairs, the input to your custom helper will turn into only one associative array. For example, when your custom helper is `function ($input) {...}`:
 
 ```
@@ -232,6 +230,35 @@ When you pass arguments as `name=value` pairs, the input to your custom helper w
                               // so you get $input['na me'] as the string 'value'
 {{{helper url name="value"}}  // This send processed {{{url}}}  into $input[0]
                               // and the string "value" into $input['name']
+```
+
+The return value of your custom helper should be a string. When your custom helper be executed from {{ }} , the return value will be HTML encoded. You may execute your helper by {{{ }}} , then the original helper return value will be outputted directly.
+
+When you need to do different escaping or encoding logic, you can return extended information by Array($responseString, $escape_flag) , here are some custom helper return value cases:
+
+```php
+// encode is handled by lightncandy and decided by template
+// if the helper is in {{ }} , you get 'The U&amp;ME Helper is ececuted!'
+// if the helper is in {{{ }}} , you get 'The U&ME Helper is executed!'
+return 'The U&ME Helper is executed!';
+
+// Same as above because the escape_flag is DEFAULT
+// 0, false, null, undefined, or '' means DEFAULT
+return Array('The U&ME Helper is executed!');
+return Array('The U&ME Helper is executed!', false);
+return Array('The U&ME Helper is executed!', 0);
+
+// encoding is handled by the helper, lightncandy will do nothing
+// No matter in {{ }} or {{{ }}} , you get 'Exact&Same output \' \" Ya!'
+return Array('Exact&Same output \' " Ya!', 'raw');
+
+// force lightncandy html_encoded the helper result
+// No matter in {{ }} or {{{ }}} , you get 'Not&amp;Same output &#039; &quot; Ya!'
+return Array('Not&Same output \' " Ya!', 'enc');
+
+// force lightncandy encoded the helper result in handlebars.js way
+// No matter in {{ }} or {{{ }}} , you get 'Not&amp;Same output &#x27; &quot; Ya!'
+return Array('Not&Same output \' " Ya!', 'encq');
 ```
 
 Block Custom Helper

--- a/tests/LCRun2Test.php
+++ b/tests/LCRun2Test.php
@@ -278,6 +278,21 @@ class LCRun2Test extends PHPUnit_Framework_TestCase
         $this->assertEquals('=b=', $method->invoke(null,
             'a', Array('a' => 'b'), 'raw', Array('helpers' => Array('a' => function ($i) {return "={$i['a']}=";})), true
         ));
+        $this->assertEquals('=&=', $method->invoke(null,
+            'a', Array('&'), 'raw', Array('helpers' => Array('a' => function ($i) {return Array("=$i=");}))
+        ));
+        $this->assertEquals('=&amp;=', $method->invoke(null,
+            'a', Array('&'), 'enc', Array('helpers' => Array('a' => function ($i) {return Array("=$i=");}))
+        ));
+        $this->assertEquals('=&=', $method->invoke(null,
+            'a', Array('&'), 'raw', Array('helpers' => Array('a' => function ($i) {return Array("=$i=");}))
+        ));
+        $this->assertEquals('=&amp;&#039;&quot;=', $method->invoke(null,
+            'a', Array('&\'"'), 'raw', Array('helpers' => Array('a' => function ($i) {return Array("=$i=", 'enc');}))
+        ));
+        $this->assertEquals('=&amp;&#x27;&quot;=', $method->invoke(null,
+            'a', Array('&\'"'), 'raw', Array('helpers' => Array('a' => function ($i) {return Array("=$i=", 'encq');}))
+        ));
     }
 }
 ?>


### PR DESCRIPTION
The may resolve #25 and #28 .

My design is to prevent the creation of new class/method. 
Maybe this can fit into your requirement.
If this can not fullfill your usecase, please let me know, thanks.

**Here is the updated document**

The return value of your custom helper should be a string. When your custom helper be executed from {{ }} , the return value will be HTML encoded. You may execute your helper by {{{ }}} , then the original helper return value will be outputted directly.

When you need to do different escaping or encoding logic, you can return extended information by Array($responseString, $escape_flag) , here are some custom helper return value cases:

``` php
// encode is handled by lightncandy and decided by template
// if the helper is in {{ }} , you get 'The U&amp;ME Helper is ececuted!'
// if the helper is in {{{ }}} , you get 'The U&ME Helper is executed!'
return 'The U&ME Helper is executed!';

// Same as above because the escape_flag is DEFAULT
// 0, false, null, undefined, or '' means DEFAULT
return Array('The U&ME Helper is executed!');
return Array('The U&ME Helper is executed!', false);
return Array('The U&ME Helper is executed!', 0);

// encoding is handled by the helper, lightncandy will do nothing
// No matter in {{ }} or {{{ }}} , you get 'Exact&Same output \' \" Ya!'
return Array('Exact&Same output \' " Ya!', 'raw');

// force lightncandy html_encoded the helper result
// No matter in {{ }} or {{{ }}} , you get 'Not&amp;Same output &#039; &quot; Ya!'
return Array('Not&Same output \' " Ya!', 'enc');

// force lightncandy encoded the helper result in handlebars.js way
// No matter in {{ }} or {{{ }}} , you get 'Not&amp;Same output &#x27; &quot; Ya!'
return Array('Not&Same output \' " Ya!', 'encq');
```
