### PR TITLE
fix for mustache spec

### DIFF
--- a/src/lightncandy.php
+++ b/src/lightncandy.php
@@ -1690,9 +1690,11 @@ class LCRun3 {
      * @expect false when input Array(), 0
      * @expect true when input Array(), false
      * @expect false when input Array(), 'false'
+     * @expect true when input Array(), Array()
+     * @expect false when input Array(), Array('1')
      */
     public static function isec($cx, $v) {
-        return is_null($v) || ($v === false);
+        return is_null($v) || ($v === false) || (is_array($v) && (count($v) === 0));
     }
 
     /**

--- a/tests/LCRun3Test.php
+++ b/tests/LCRun3Test.php
@@ -125,6 +125,12 @@ class LCRun3Test extends PHPUnit_Framework_TestCase
         $this->assertEquals(false, $method->invoke(null,
             Array(), 'false'
         ));
+        $this->assertEquals(true, $method->invoke(null,
+            Array(), Array()
+        ));
+        $this->assertEquals(false, $method->invoke(null,
+            Array(), Array('1')
+        ));
     }
     /**
      * @covers LCRun3::raw


### PR DESCRIPTION
`{{^foo}} inner block should be rendered {{/foo}}` when foo == []
