### PR TITLE
Prevent detection of named variables inside quoted strings

### DIFF
--- a/src/lightncandy.php
+++ b/src/lightncandy.php
@@ -1130,6 +1130,7 @@ $libstr
      * @expect array(false, array(array('a'), 'q' => array('b'), array('c'))) when input array(0,0,0,0,0,0,'a [q]=b c'), array('flags' => array('advar' => 0, 'this' => 1, 'namev' => 1))
      * @expect array(false, array(array('a'), 'q' => array('"b c"'))) when input array(0,0,0,0,0,0,'a q="b c"'), array('flags' => array('advar' => 1, 'this' => 1, 'namev' => 1))
      * @expect array(false, array(array('(foo bar)'))) when input array(0,0,0,0,0,0,'(foo bar)'), array('flags' => array('advar' => 1, 'this' => 1, 'namev' => 1))
+     * @expect array(false, array(array('"!=="'))) when input array(0,0,0,0,0,0,'"!=="'), array('flags' => array('namev' => 1))
      */
     protected static function parseTokenArgs(&$token, &$context) {
         trim($token[self::POS_INNERTAG]);
@@ -1203,8 +1204,8 @@ $libstr
         $ret = array();
         $i = 0;
         foreach ($vars as $idx => $var) {
-            // Skip advanced processing for subexpressions
-            if (preg_match('/^\(.+\)$/', $var)) {
+            // Skip advanced processing for subexpressions and quoted strings
+            if (preg_match('/^\(.+\)$/', $var) || preg_match('/^".*"$/', $var)) {
                 $ret[$i] = array($var);
                 $i++;
                 continue;

--- a/tests/LightnCandyTest.php
+++ b/tests/LightnCandyTest.php
@@ -361,6 +361,9 @@ class LightnCandyTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(array(false, array(array('(foo bar)'))), $method->invoke(null,
             array(0,0,0,0,0,0,'(foo bar)'), array('flags' => array('advar' => 1, 'this' => 1, 'namev' => 1))
         ));
+        $this->assertEquals(array(false, array(array('"!=="'))), $method->invoke(null,
+            array(0,0,0,0,0,0,'"!=="'), array('flags' => array('namev' => 1))
+        ));
     }
     /**
      * @covers LightnCandy::tokenString


### PR DESCRIPTION
Passing a string like "===" with named variables enabled was being
processed as a named argument.  Adjust handling so that quoted strings
are passed through as is.
