### PR TITLE
Remove ?>\n closing file

### DIFF
--- a/src/lightncandy.php
+++ b/src/lightncandy.php
@@ -2471,4 +2471,3 @@ class LCRun3 {
         return $ret;
     }
 }
-?>


### PR DESCRIPTION
A \n in the end of the file will generate output and interfere with header(). Since PHP doesn't need the final ?>, it's better to just remove it.
