### PR TITLE
Use classmap autoloading in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,6 @@
         "phpunit/phpunit": "4.0.17"
     },
     "autoload": {
-        "files": ["src/lightncandy.php"]
+        "classmap": ["src/lightncandy.php"]
     }
 }


### PR DESCRIPTION
When installing via composer, using "files" causes the entire file
to be loaded when the autoloader is initialized. Using classmap
actually uses the autoloader as a real autoloader, the files are
only loaded when the class is invoked.

See https://getcomposer.org/doc/04-schema.md#files and
https://getcomposer.org/doc/04-schema.md#classmap for more details.
