### PR TITLE
Callbacks inside partial should be aware of $sp

### DIFF
--- a/src/lightncandy.php
+++ b/src/lightncandy.php
@@ -543,6 +543,8 @@ $libstr
             if ($context['flags']['mustpi']) {
                 $sp = ', $sp';
                 $code = preg_replace('/^/m', "'{$context['ops']['seperator']}\$sp{$context['ops']['seperator']}'", $code);
+                // callbacks inside partial should be aware of $sp
+                $code = preg_replace('/\bfunction\s*\((.*?)\)\s*{/', 'function(\\1)use($sp){', $code);
             } else {
                 $sp = '';
             }


### PR DESCRIPTION
'.$sp.' will be added at the beginning of every line.
However, inside a partial, it is possible to have callbacks (e.g. hbch) that span multiple lines.
Those callback functions will have no notion of what this $sp variable is, resulting in a:

    Notice: Undefined variable: sp in ...

--

This will alter those closures to include a "use ($sp)", resulting in e.g.:

    function($cx, $in){/*the code*/}

will turn into:

    function($cx, $in)use($sp){/*the code*/}

--

This regex is not foolproof; it could mistake default argument values for code, should a default value include '){'. e.g.:

    function($blah = '){'){/*the code*/}

would turn into:

    function($blah = ')use($sp){'){/*the code*/}

Currently, however, none of the closures even has default values, AFAICT, so this is not really an issue.