### PR TITLE
Pass the old context to handlebars helpers as well as the context given by the user

### DIFF
--- a/src/lightncandy.php
+++ b/src/lightncandy.php
@@ -2506,7 +2506,8 @@ class LCRun3 {
         $args = $vars[0];
         $options = array(
             'name' => $ch,
-            'hash' => $vars[1]
+            'hash' => $vars[1],
+            'old_ctx' => $isBlock ? $op : end( $cx['scopes'] ),
         );
 
         // $invert the logic


### PR DESCRIPTION
I want to be able to refer back to the old context in an HBHelper. This pull request passes this as old_ctx in the `$options` array

For example:

```php
$phpStr = LightnCandy::compile( "{{#myhelper \"foo\"}}",
  array(
    'flags' => LightnCandy::FLAG_MUSTACHE,
    'hbhelpers' => array(
      'myhelper' =>
        function( $context, array $options ) {
          // How do I get the value of myParam?
          // By looking in $options['old_ctx']['myParam'], that's how.
        }
    )
  );

$fn = LightnCandy::prepare( $phpStr );
print $fn( array( 'myParam' => 'myValue' ) );
```