### PR TITLE
Update lightncandy.php

### DIFF
--- a/src/lightncandy.php
+++ b/src/lightncandy.php
@@ -2442,7 +2442,14 @@ class LCRun3 {
      *
      */
     public static function p($cx, $p, $v, $sp = '') {
-        return call_user_func($cx['partials'][$p], $cx, is_array($v[0][0]) ? array_merge($v[0][0], $v[1]) : $v[0][0], $sp);
+        return call_user_func(
+            $cx['partials'][$p],
+            $cx,
+            is_array($v[0][0]) ?
+                array_merge($v[0][0], $v[1]) :
+                (!empty($v[1]) ? $v[1] : $v[0][0] ),
+            $sp
+        );
     }
 
     /**


### PR DESCRIPTION
Ability to pass data to a partial, if the first argument is not an array. 
`#each` example:

```handlebars
{{#each group.products}}
    {{>product_item test="test_str"}} {{!-- whill throw Calling unknown method: Product::test() --}}
{{/each}}
```

partial `product_item`:
```handlebars
{{test}} {{!-- brocked --}}
{{this.id}}
```

I think, for this purpose, it should be
```handlebars
{{#each group.products}}
    {{>product_item product=. test="test_str"}}
{{/each}}
```

and
```handlebars
{{test}}
{{product.id}}
```