### PR TITLE
Added support for custom delimeters when compiling a template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+build/result

--- a/src/lightncandy.php
+++ b/src/lightncandy.php
@@ -120,7 +120,13 @@ class LightnCandy {
         $context['scan'] = false;
 
         // Do PHP code generation.
-        static::setupToken($context);
+
+        if (isset($options['delimiters'])) {
+            static::setupToken($context, $options['delimiters']['left'], $options['delimiters']['right']);
+        }
+        else {
+            static::setupToken($context);
+        }
 
         // Handle dynamic partials
         static::handleDynamicPartial($context);

--- a/tests/LightnCandyTest.php
+++ b/tests/LightnCandyTest.php
@@ -540,5 +540,36 @@ class LightnCandyTest extends PHPUnit_Framework_TestCase
             array('usedCount' => array('test' => array('testname' => 2))), 'test', 'testname', 3
 )        ));
     }
+
+    public function testCustomDelimiters() {
+        $tmpdir = sys_get_temp_dir();
+
+        $foo = 'bar';
+
+        $template = <<<TEMPLATE
+These are some variables [[foo]] {{foo}} where only one should get replaced.
+TEMPLATE;
+
+        $expected = <<<EXPECTED
+These are some variables {$foo} {{foo}} where only one should get replaced.
+EXPECTED;
+
+        $flags = LightnCandy::FLAG_HANDLEBARSJS |
+                 LightnCandy::FLAG_ERROR_EXCEPTION;
+
+        $php = LightnCandy::compile($template, Array(
+            'flags' => $flags,
+            'basedir' => $tmpdir,
+            'delimiters' => Array(
+                'left' => '[[',
+                'right' => ']]',
+            ),
+        ));
+
+        $renderer = LightnCandy::prepare($php);
+        $actual = $renderer(array('foo' => $foo));
+
+        $this->assertEquals($expected, $actual);
+    }
 }
 ?>


### PR DESCRIPTION
Hi,

I have the use case where I want to compile and render a template that is using custom delimiters. As far as I could see, there was no way to setup the initial tokens with different delimiters; only during one (which would require the use of the ``{{ }}`` delimiters).

This PR adds that functionality so that you can pass in, via options, custom delimiters with which to render the entire template.

I had a look at the tests structure and most compile + render tests are using the handlebars or moustache specs; lightncandy doesn't seem to have any of its own. To that end I've added it to the Lightncandy class tests, but I'm happy to discuss a better location for them (or even a completely different methodology for testing this feature).

I've also added a ``.gitignore`` file to ignore test coverage results so they aren't accidentally committed.