### PR TITLE
support callable as external helpers

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -71,6 +71,9 @@ class Exporter
                 $ret .= ("            '$name' => " . static::closure($context, $func) . ",\n");
                 continue;
             }
+            if (is_callable($func) && ($context['flags']['exhlp'] == LightnCandy::FLAG_EXTHELPER)) {
+                continue;
+            }
             $ret .= "            '$name' => '$func',\n";
         }
 

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -71,7 +71,7 @@ class Exporter
                 $ret .= ("            '$name' => " . static::closure($context, $func) . ",\n");
                 continue;
             }
-            if (is_callable($func) && ($context['flags']['exhlp'] == LightnCandy::FLAG_EXTHELPER)) {
+            if (($context['flags']['exhlp'] == LightnCandy::FLAG_EXTHELPER) && is_array($func) && is_callable($func)) {
                 continue;
             }
             $ret .= "            '$name' => '$func',\n";


### PR DESCRIPTION
This one is a bit special, as there are two requirements to support callable

The compilation step would look like this:

```
// LightnCandy sample, #mywith works same with #with
$php = LightnCandy::compile($template, Array(
    'flags' => LightnCandy::FLAG_HANDLEBARSJS |  LightnCandy::FLAG_EXTHELPER,
    'helpers' => [
       'myHelper' => [$helperInstance, 'helperMethod']
   ]
));
```

And on runtime you have to do this:

```
// Get the render function
$renderer = include('template.php');

$renderer(['name' => 'John'], ['helpers' => ['myHelper' => [$helperInstance, 'helperMethod']]]);
```

Closes #228 
