### PR TITLE
Add branch-alias for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,10 @@
         "psr-4": {
             "LightnCandy\\": "src"
         }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "v0.95-dev"
+        }
     }
 }


### PR DESCRIPTION
Add a branch alias for the next version, to allow the possibility to install the master branch by requiring a comparable version (for instance, `"zordius/lightncandy": "~0.92"`) and setting the "minimum-stability" attribute to "dev".