### PR TITLE
Fix named references in each helper if variable is string/integer (fix #267)

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,7 @@ Go http://handlebarsjs.com/ to see more feature description about handlebars.js.
 * `{{! comment}}` : comment
 * `{{!-- comment or {{ or }} --}}` : extended comment that can contain }} or {{ .
 * `{{=<% %>=}}` : set delimiter to custom string , the custom string can not contain `=` . Check http://mustache.github.io/mustache.5.html for more example.
+* `{{#each var as |value key|}}` : each loop with named parameters
 * `{{#each var}}` : each loop
 * `{{#each}}` : each loop on {{.}}
 * `{{/each}}` : end loop

--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -370,7 +370,7 @@ class Runtime extends Encoder
                     $i++;
                 }
                 if (isset($bp[0])) {
-                    $raw = static::m($cx, $raw, array($bp[0] => $raw));
+                    $raw = static::m($cx, $raw, array($bp[0] => $raw), true);
                 }
                 if (isset($bp[1])) {
                     $raw = static::m($cx, $raw, array($bp[1] => $cx['sp_vars']['index']));
@@ -466,11 +466,16 @@ class Runtime extends Encoder
      * @param array<string,array|string|integer> $cx render time context for lightncandy
      * @param array<array|string|integer>|string|integer|null $a the context to be merged
      * @param array<array|string|integer>|string|integer|null $b the new context to overwrite
+     * @param boolean $c convert a non array/object to an array first
      *
      * @return array<array|string|integer>|string|integer the merged context object
      *
      */
-    public static function m($cx, $a, $b) {
+    public static function m($cx, $a, $b, $c = false) {
+        if ($c && !is_array($a) && !is_object($a)) {
+            $a = array($a);
+        }
+
         if (is_array($b)) {
             if ($a === null) {
                 return $b;


### PR DESCRIPTION
Tried to fix the issue described in #267. By applying this PR it's possible to use named references. Before it only worked if the value was an array or object. e.g.

```
{{#each users as |userName userId|}}
  Id: {{userId}} Name: {{userName}}
{{/each}}
```

This is my first contribution for lightncandy and I'm unsure if this PR fits into the overall architecture or if there's a better place to fix this issue.