### PR TITLE
tests: Fix "Undefined index: data in regressionTest.php:26" error

### DIFF
--- a/tests/regressionTest.php
+++ b/tests/regressionTest.php
@@ -23,7 +23,7 @@ class regressionTest extends PHPUnit_Framework_TestCase
         }
         $renderer = LightnCandy::prepare($php);
 
-        $this->assertEquals($issue['expected'], $renderer($issue['data'], array('debug' => $issue['debug'])), "PHP CODE:\n$php\n$parsed");
+        $this->assertEquals($issue['expected'], $renderer(isset($issue['data']) ? $issue['data'] : null, array('debug' => $issue['debug'])), "PHP CODE:\n$php\n$parsed");
     }
 
     public function issueProvider()


### PR DESCRIPTION
This is emitted many times when running PHPUnit, both locally and on Travis,
at <https://travis-ci.org/zordius/lightncandy/jobs/463870225>.

The implicit behaviour when an index is not found in PHP, is to continue
as if it was null. The code now does this explicitly, without error.