### PR TITLE
Cache compiled templates to improve compiler speed & reduce memory usage

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -31,6 +31,8 @@ class Compiler extends Validator
 {
     public static $lastParsed;
 
+    protected static $templateCache = [];
+
     /**
      * Compile template into PHP code
      *
@@ -40,6 +42,12 @@ class Compiler extends Validator
      * @return string|null generated PHP code
      */
     public static function compileTemplate(&$context, $template) {
+        $hash = md5($template);
+
+        if ( isset(self::$templateCache[$hash]) ) {
+            return self::$templateCache[$hash];
+        }
+
         array_unshift($context['parsed'], array());
         Validator::verify($context, $template);
         static::$lastParsed = $context['parsed'];
@@ -67,6 +75,8 @@ class Compiler extends Validator
         }
 
         array_shift($context['parsed']);
+
+        self::$templateCache[$hash] = $code;
 
         return $code;
     }

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -42,7 +42,7 @@ class Compiler extends Validator
      * @return string|null generated PHP code
      */
     public static function compileTemplate(&$context, $template) {
-        $hash = md5(json_encode($context).$template);
+        $hash = md5($template);
 
         if ( isset(self::$templateCache[$hash]) ) {
             return self::$templateCache[$hash];

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -42,7 +42,7 @@ class Compiler extends Validator
      * @return string|null generated PHP code
      */
     public static function compileTemplate(&$context, $template) {
-        $hash = md5($template);
+        $hash = md5(json_encode($context).$template);
 
         if ( isset(self::$templateCache[$hash]) ) {
             return self::$templateCache[$hash];


### PR DESCRIPTION
The library works really well, i've seen in 8-10x increase in render performance since switching to it, so would firstly like to thank you for the hard work you have put into this. 

We have a use case where there is a partial (the icon partial) that is used regularly but is a very large file, it's a mustache svg sprite where each svg markup within a conditional statement: `{{#conditional}}<svg>*svg markup*</svg>{{/conditional}}`.

There are 250+ of these conditional statements and I found that the renderer was running out of memory when trying to render a few templates that used the icon partial. 

The error message pointed to line 42 of the `Validator.php` file. I realised that the icon partial (and others) was being re-compiled multiple times and php was running out of memory during the process. Just to put into context, it gave up after allocating over 120mb of memory.

I addressed this by implementing a template cache so the compilation of a template is done only once. I think a general refactor is needed as passing the `$context` array around as a reference and adding to it in various parts of the code base could be optimised, but I think it would end up being quite a bit of work. For now, this should do :)