### PR TITLE
Update Runtime.php

### DIFF
--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -169,8 +169,16 @@ class Runtime extends Encoder
                         continue;
                     }
                     if ($cx['flags']['method'] && is_callable(array($v, $name))) {
-                        $v = $v->$name();
-                        continue;
+                        try {
+                            $v = $v->$name();
+                            continue;
+                        } catch (\BadMethodCallException $e) {}
+                    }
+                    if ($v instanceof \ArrayAccess) {
+                        if (isset($v[$name])) {
+                            $v = $v[$name];
+                            continue;
+                        }
                     }
                 }
                 if ($cx['flags']['mustlok']) {


### PR DESCRIPTION
1. Adds support for objects implementing ArrayAccess interface.
2. Ignoring BadMethodCallException which is useful when an object implements the magic __call method. The is_callable check is not sufficient in this case because every method would be considered "callable" when an object has the __call method on it.