### PR TITLE
Bump php requirement to >= 7.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 dist: trusty
 sudo: required
 php:
-  - 7.0
   - 7.1
   - 7.2
   - 7.3

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=7.1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7"


### PR DESCRIPTION
Uses phpunit 7, which needs 7.1...

If we're not testing on old version, we can't really say we support it