### PR TITLE
Stop trying to access an int as an array

### DIFF
--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -198,7 +198,7 @@ class Runtime extends Encoder
                     if ($cx['flags']['mustlam'] || $cx['flags']['lambda']) {
                         if (!$cx['flags']['knohlp'] && ($args || ($args === 0))) {
                             $A = $args ? $args[0] : array();
-                            $A[] = array('hash' => $args[1], '_this' => $in);
+                            $A[] = array('hash' => is_array( $args ) ? $args[1] : null, '_this' => $in);
                         } else {
                             $A = array($in);
                         }


### PR DESCRIPTION
Causes a notice on PHP 7.4, whereas on older versions, 0[1] ends up as null

Fixes the other issues in https://github.com/zordius/lightncandy/issues/327