### PR TITLE
feat: deterministic function prefixes for FLAG_STANDALONEPHP

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -140,7 +140,7 @@ class Context extends Flags
             'safestring' => '\\LightnCandy\\SafeString',
             'safestringalias' => isset($options['safestring']) ? $options['safestring'] : 'LS',
             'rawblock' => false,
-            'funcprefix' => 'lcr' . md5( $template ),
+            'funcprefix' => isset($options['funcprefix']) && is_callable($options['funcprefix']) ? $options['funcprefix']( $options, $template ) : uniqid('lcr')
         );
 
         $context['ops'] = $context['flags']['echo'] ? array(

--- a/src/Context.php
+++ b/src/Context.php
@@ -31,7 +31,7 @@ class Context extends Flags
      *
      * @return array<string,array|string|integer> Context from options
      */
-    public static function create($options)
+    public static function create($options, $template)
     {
         if (!is_array($options)) {
             $options = array();
@@ -140,7 +140,7 @@ class Context extends Flags
             'safestring' => '\\LightnCandy\\SafeString',
             'safestringalias' => isset($options['safestring']) ? $options['safestring'] : 'LS',
             'rawblock' => false,
-            'funcprefix' => uniqid('lcr'),
+            'funcprefix' => 'lcr' . md5( $template ),
         );
 
         $context['ops'] = $context['flags']['echo'] ? array(

--- a/src/LightnCandy.php
+++ b/src/LightnCandy.php
@@ -37,7 +37,7 @@ class LightnCandy extends Flags
      */
     public static function compile($template, $options = array('flags' => self::FLAG_BESTPERFORMANCE))
     {
-        $context = Context::create($options);
+        $context = Context::create($options, $template);
 
         if (static::handleError($context)) {
             return false;
@@ -67,7 +67,7 @@ class LightnCandy extends Flags
      */
     public static function compilePartial($template, $options = array('flags' => self::FLAG_BESTPERFORMANCE))
     {
-        $context = Context::create($options);
+        $context = Context::create($options, $template);
 
         if (static::handleError($context)) {
             return false;


### PR DESCRIPTION
First of all: thank your for this great library!

To better illustrate my request, I'm adding this as a PR (instead of an issue). I'm not sure about all the implications (also regarding performance and compilation of partials), but I don't have any issues with my PR (feel free to decline, this is also meant for better understanding my issue).

I write parsed handlebars-code to a standalone php-file (FLAG_STANDALONEPHP) as you propose in my development-environment (on every page load). Every time the (same) file is rendered, different code is generated (only when FLAG_STANDALONEPHP is used). This causes lot's of changes (when those rendered files are tracked via git) even if nothing actually changed.

Looking at the diffs only the function-names are changing, because ``uniqid`` is used to prefix functions:
https://github.com/zordius/lightncandy/blob/2beab0f1add20a9ddaa58e5d229e52c1d1b9c3b0/src/Context.php#L143

Instead of using a ``uniquid`` we could base the function prefixes on the contents of the parsed template (hashed with md5?). This way the prefixes would be deterministic and the prefixes would only change if the contents of the source (handlebars-/mustache-) files change.

Thanks!

Running the tests poses some issues, as the same templates are used multiple times (of course) and lead to ``Fatal error: Cannot redeclare lcr31a8f7b63d1d5a1b9da615f756a3dbf0v()``. I tried ``--process-isolation`` for phpunit, but that creates another issue ``Serialization of 'Closure' is not allowed``. Instead of digging deeper I'm looking forward to your thoughts on this.

Edit: I made the funcprefix an option which falls back to ``uniqid()``, so now there are no issues with the tests. 