### PR TITLE
fix: Pass input data of current scope to {{else}} of {{#each}}

### DIFF
--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -351,6 +351,7 @@ class Runtime extends Encoder
      * @expect 'cb' when input array('flags' => array('spvar' => 0, 'mustlam' => 0, 'mustsec' => 0, 'lambda' => 0)), new stdClass, null, 0, false, function ($c, $i) {return 'cb';}, function ($c, $i) {return 'inv';}
      * @expect '268' when input array('scopes' => array(), 'flags' => array('spvar' => 1, 'mustlam' => 0, 'lambda' => 0), 'sp_vars'=>array('root' => 0)), array(1,3,4), null, 0, false, function ($c, $i) {return $i * 2;}
      * @expect '038' when input array('scopes' => array(), 'flags' => array('spvar' => 1, 'mustlam' => 0, 'lambda' => 0), 'sp_vars'=>array('root' => 0)), array(1,3,'a'=>4), null, 0, true, function ($c, $i) {return $i * $c['sp_vars']['index'];}
+     * @expect 'inv' when input array('flags' => array('spvar' => 0, 'mustlam' => 0, 'lambda' => 0)), null, null, array('foo' => 'inv'), true, function ($c, $i) {return 'cb';}, function ($c, $i) {return $i['foo'];}
      */
     public static function sec($cx, $v, $bp, $in, $each, $cb, $else = null)
     {
@@ -429,7 +430,7 @@ class Runtime extends Encoder
         }
         if ($each) {
             if ($else !== null) {
-                $ret = $else($cx, $v);
+                $ret = $else($cx, $in);
                 return $ret;
             }
             return '';

--- a/tests/RuntimeTest.php
+++ b/tests/RuntimeTest.php
@@ -214,6 +214,9 @@ class RuntimeTest extends TestCase
         $this->assertEquals('038', $method->invokeArgs(null, array_by_ref(array(
             array('scopes' => array(), 'flags' => array('spvar' => 1, 'mustlam' => 0, 'lambda' => 0), 'sp_vars'=>array('root' => 0)), array(1,3,'a'=>4), null, 0, true, function ($c, $i) {return $i * $c['sp_vars']['index'];}
         ))));
+        $this->assertEquals('inv', $method->invokeArgs(null, array_by_ref(array(
+            array('flags' => array('spvar' => 0, 'mustlam' => 0, 'lambda' => 0)), null, null, array('foo' => 'inv'), true, function ($c, $i) {return 'cb';}, function ($c, $i) {return $i['foo'];}
+        ))));
     }
     /**
      * @covers LightnCandy\Runtime::wi


### PR DESCRIPTION
## Problem

Given the following Handlebars template:

```handlebars
{{#each paragraphs}}
    <p>{{this}}</p>
{{else}}
    <p class="empty">{{foo}}</p>
{{/each}}
```

Given the following context:

```json
{
    "foo": "baz"
}
```

When rendering the template with this context, `{{else}}` is being rendered because `paragraphs` is missing in the context. With native handlebars.js, this generates the following result:

```html
<p class="empty">baz</p>
```

> 👉 For reference, have a look at the [playground on handlebarsjs.com](https://handlebarsjs.com/playground.html#format=1&currentExample=%7B%22template%22%3A%22%7B%7B%23each%20paragraphs%7D%7D%5Cn%3Cp%3E%7B%7Bthis%7D%7D%3C%2Fp%3E%5Cn%7B%7Belse%7D%7D%5Cn%3Cp%20class%3D%5C%22empty%5C%22%3E%7B%7Bfoo%7D%7D%3C%2Fp%3E%5Cn%7B%7B%2Feach%7D%7D%22%2C%22partials%22%3A%5B%5D%2C%22input%22%3A%22%7B%5Cn%20%20%20%20%5C%22foo%5C%22%3A%20%5C%22baz%5C%22%5Cn%7D%5Cn%22%2C%22output%22%3A%22%3Cp%20class%3D%5C%22empty%5C%22%3Ebaz%3C%2Fp%3E%5Cn%22%2C%22preparationScript%22%3A%22%22%2C%22handlebarsVersion%22%3A%224.7.7%22%7D).

However, when rendering the same template and context with lightncandy, the result is:

```
<p class="empty"></p>
```

> 👉 For reference, create and run the following PHP script:
>
> ```php
> require_once __DIR__ . '/vendor/autoload.php';
> 
> $template = <<<HBS
> {{#each paragraphs}}
>     <p>{{this}}</p>
> {{else}}
>     <p class="empty">{{foo}}</p>
> {{/each}}
> HBS;
> 
> $compileResult = \LightnCandy\LightnCandy::compile($template, [
>     'flags' => \LightnCandy\LightnCandy::FLAG_HANDLEBARS,
> ]);
> $fn = \LightnCandy\LightnCandy::prepare($compileResult);
> 
> echo $fn([
>     'foo' => 'baz',
> ]);
> ```
>
> And check the output:
>
> ```bash
> $ php test.php
> <p class="empty"></p>
> ```

## Solution

This PR fixes the issue by passing input data of the current scope to the `else` callback in `Runtime::sec()`. In addition, a test case is added which covers the above scenario.